### PR TITLE
PR-4096: Expose fields from CSE Packages for RN SDK 

### DIFF
--- a/Sources/PayrailsCSE/PayrailsCSE.swift
+++ b/Sources/PayrailsCSE/PayrailsCSE.swift
@@ -154,7 +154,7 @@ public struct PayrailsCSE {
     }
 }
 
-struct Card: Codable {
+public struct Card: Codable {
     var holderReference: String
     var cardNumber: String
     var expiryMonth: String
@@ -215,6 +215,7 @@ public struct InstrumentData: Codable {
     public let expiryYear: String?
     public let paymentToken: String?
     public let email: String?
+    public let network: String?
 }
 
 public enum InstrumentStatus: String, Codable {


### PR DESCRIPTION
Exposed the `Card` struct as it's type will be used by the RN SDK 
Exposed the `network` field as it's required by the RN SDK tokenization response