### PR TITLE
PR-4962: Error cases changes

### DIFF
--- a/PayrailsCSE.podspec
+++ b/PayrailsCSE.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'PayrailsCSE'
-  s.version          = '0.2.0'
+  s.version          = '1.0.0'
   s.summary          = 'Payrails client-side encryption SDK'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
- Added new convention for error codes
- Handled config parsing error by throwing exceptions instead of a fatal error
**NOTE: This PR introduces a breaking change, merchant using the SDK will need to wrap the init call with a do..try statement. Since it's throws exceptions now**