### PR TITLE
CHK-347: update minimum ios cse version

### DIFF
--- a/.github/workflows/naming.yaml
+++ b/.github/workflows/naming.yaml
@@ -7,4 +7,4 @@ jobs:
     name: Reusable
     uses: payrails/actions/.github/workflows/reusable-naming.yaml@main
     secrets:
-      jira_token: ${{ secrets.JIRA_TOKEN }}
+      linear_api_key_read: ${{ secrets.LINEAR_API_KEY_READ }}

--- a/PayrailsCSE.podspec
+++ b/PayrailsCSE.podspec
@@ -28,7 +28,7 @@ SDK provides client side encryption and tokenization on Payrails platform.
   s.author           = { 'Payrails' => 'contact@payrails.com' }
   s.source           = { :git => 'https://github.com/payrails/ios-cse.git', :tag => s.version.to_s }
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '13.0'
 
   s.source_files = 'Sources/**/*'
   s.dependency 'JOSESwift'


### PR DESCRIPTION
update minimum iOS CSE version as JOSE dropped support for ios version less than 13. 